### PR TITLE
Enable http_realip module during nginx build

### DIFF
--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -22,6 +22,7 @@ pushd nginx-1.4.5
     --add-module=../headers-more-nginx-module-0.25 \
     --with-http_ssl_module \
     --with-http_dav_module \
+    --with-http_realip_module \
     --add-module=../nginx-upload-module-2.2
 
   make


### PR DESCRIPTION
This allows use of the PROXY protocol to correctly set the X-Forwarded-For header when terminating SSL behind another load balancer.

http://nginx.org/en/docs/http/ngx_http_realip_module.html
