### PR TITLE
Add some option to use nginx Stream directive

### DIFF
--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -23,7 +23,10 @@ pushd nginx-1.11.7
     --with-http_realip_module \
     --with-http_gunzip_module \
     --with-http_v2_module \
-    --with-stream
+    --with-stream \
+    --with-threads \
+    --with-stream_ssl_module \
+    --with-http_slice_module
 
   make
   make install


### PR DESCRIPTION
Hello, I'm creating a release for Bitbucket and I want to use your nginx release. When I use the stream directive I have this error. Can you add the following option in your release for the stream option to work?     
     --with-threads \
    --with-stream_ssl_module \
    --with-http_slice_module