### PR TITLE
Enabling --with-http_stub_status_module within the nginx package

### DIFF
--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -34,6 +34,7 @@ pushd nginx-1.12.1
     --with-threads \
     --with-stream_ssl_module \
     --with-http_slice_module \
+    --with-http_stub_status_module \
     --add-module=../nginx-upload-module-2.2
 
   make


### PR DESCRIPTION
Adding --with-http_stub_status_module flag, will allow us to expose an endpoint that shows basic status information. This is needed as our first step in enabling [newrelic infrastructure](https://docs.newrelic.com/docs/infrastructure/integrations/nginx-integration-new-relic-infrastructure#config) to monitor for Nginx environment. 

Related doc: http://nginx.org/en/docs/http/ngx_http_stub_status_module.html

/cc @cunnie 