### PR TITLE
Support to render a htpasswd file for basic auth

### DIFF
--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -43,3 +43,8 @@ properties:
       "COMODO RSA Certification Authority").  There is no reason to include the
       root certificate, but there is no harm in including it either. It should
       be the last certificate (bottom-most).
+  htpasswd_users:
+    description: List of users and paswords to add in a generated htpasswd file
+    example:
+      - name: marissa
+        password: koala

--- a/jobs/nginx/templates/ctl.sh
+++ b/jobs/nginx/templates/ctl.sh
@@ -13,13 +13,26 @@ PIDFILE=$RUN_DIR/$JOB_NAME.pid
 
 mkdir -p $RUN_DIR $LOG_DIR $CONFIG_DIR
 
-case $1 in
+<%- if_p('htpasswd_users') do |htpasswd_users| -%>
+generate_htpasswd() {
+<%- htpasswd_users.each do |entry| -%>
+  echo "<%= entry['name'] %>:$(echo <%= entry['password'] %> | openssl passwd -apr1 -stdin)"
+<%- end -%>
+}
+<%- end -%>
 
+case $1 in
   start)
+<%- if_p('htpasswd_users') do -%>
+    generate_htpasswd > $CONFIG_DIR/htpasswd.conf
+<%- end -%>
     $BASE_DIR/packages/nginx/sbin/$JOB_NAME -g "pid $PIDFILE;" -c $CONFIG_FILE
     ;;
   stop)
     kill $(cat $PIDFILE)
+<%- if_p('htpasswd_users') do -%>
+    rm -f $CONFIG_DIR/htpasswd.conf
+<%- end -%>
     ;;
   *)
     echo "Usage: ctl {start|stop}"


### PR DESCRIPTION
In order to support basic authentication in nginx, a htpaswd file
must be generated. This commit automatically generates the files
for a provided list of users/password.

To use/test it:
```
   - name: nginx
      release: nginx
      properties:
         htpasswd_users:
         - name: user
           password: p4ss
         - name: test
           password: aaa
         nginx_conf: |
         ...
         http {
            server {
               ...
               auth_basic           "Alto, santo y senha!";
               auth_basic_user_file /var/vcap/jobs/nginx/etc/htpasswd.conf;
            }
         }
```