### PR TITLE
provide http-router bosh link

### DIFF
--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -10,6 +10,10 @@ templates:
 packages:
 - nginx
 
+provides:
+- name: http-server
+  type: http-router
+
 properties:
   nginx_conf:
     description: 'The contents of nginx.conf, the primary configuration file'


### PR DESCRIPTION
Providing this link makes loadbalancing nginx servers with the HA proxy release really easy since ha-proxy release consumes http-router links.