### PR TITLE
Capture output of running nginx to log files

### DIFF
--- a/jobs/nginx/templates/ctl.sh
+++ b/jobs/nginx/templates/ctl.sh
@@ -16,7 +16,9 @@ mkdir -p $RUN_DIR $LOG_DIR $CONFIG_DIR
 case $1 in
 
   start)
-    $BASE_DIR/packages/nginx/sbin/$JOB_NAME -g "pid $PIDFILE;" -c $CONFIG_FILE
+    $BASE_DIR/packages/nginx/sbin/$JOB_NAME -g "pid $PIDFILE;" -c $CONFIG_FILE \
+      >>${LOG_DIR}/stdout.log \
+      2>>${LOG_DIR}/stderr.log
     ;;
   stop)
     kill $(cat $PIDFILE)


### PR DESCRIPTION
Just a quick fix so that errors such as an invalid nginx.conf will show up in bosh logs